### PR TITLE
Summarize template changes after --improve-prompts (#23)

### DIFF
--- a/fix_die_repeat/runner_improve_prompts.py
+++ b/fix_die_repeat/runner_improve_prompts.py
@@ -10,6 +10,7 @@ mutated.
 import logging
 import shutil
 from collections.abc import Callable
+from dataclasses import dataclass
 from importlib import resources
 from pathlib import Path
 
@@ -44,6 +45,15 @@ EDITABLE_TEMPLATES = (
 # Non-zero exit code returned when pi succeeds but leaves the introspection
 # or archive file unparseable, so the user notices the rollback.
 _ROLLBACK_EXIT_CODE = 1
+
+
+@dataclass(frozen=True)
+class _RunPiResult:
+    """Outcome of ``_run_pi_with_rollback``, with counts captured under the file lock."""
+
+    returncode: int
+    pending_before: int
+    pending_after: int
 
 
 class ImprovePromptsManager:
@@ -103,7 +113,6 @@ class ImprovePromptsManager:
         templates_dir.mkdir(parents=True, exist_ok=True)
         template_paths = self._ensure_user_templates(templates_dir)
         template_snapshot = self._snapshot_templates(template_paths)
-        pending_before = self._count_pending_entries(introspection_file)
 
         archive_file = get_introspection_archive_file_path()
         prompt = render_prompt(
@@ -117,7 +126,7 @@ class ImprovePromptsManager:
         self.logger.info(
             "[ImprovePrompts] Asking pi to review introspection data and update user templates...",
         )
-        returncode = self._run_pi_with_rollback(
+        result = self._run_pi_with_rollback(
             introspection_file=introspection_file,
             archive_file=archive_file,
             run_pi_callback=run_pi_callback,
@@ -128,16 +137,15 @@ class ImprovePromptsManager:
         # even if the same process goes on to use templates (tests do this).
         clear_prompt_cache()
 
-        if returncode != 0:
+        if result.returncode != 0:
             self.logger.warning(
                 "[ImprovePrompts] pi exited with code %s; user templates may be partially updated.",
-                returncode,
+                result.returncode,
             )
-            return returncode
+            return result.returncode
 
-        pending_after = self._count_pending_entries(introspection_file)
         changes = self._compute_template_changes(template_paths, template_snapshot)
-        entries_consumed = max(0, pending_before - pending_after)
+        entries_consumed = max(0, result.pending_before - result.pending_after)
         self._emit_summary(changes, entries_consumed)
 
         self.logger.info(
@@ -153,13 +161,15 @@ class ImprovePromptsManager:
         archive_file: Path,
         run_pi_callback: Callable[..., tuple[int, str, str]],
         prompt: str,
-    ) -> int:
+    ) -> _RunPiResult:
         """Hold an exclusive lock on the introspection file for the pi call.
 
         Acquires ``_FileLock`` on ``introspection.yaml`` so a concurrent FDR
         process appending introspection entries serializes with us. Takes a
         backup of both the main and archive files before invoking pi, and
-        rolls back if pi leaves either file unparseable.
+        rolls back if pi leaves either file unparseable. Returns the
+        before/after pending counts captured inside the lock so the summary
+        reflects this invocation's exact state rather than an interleaved view.
         """
         # Open in r+ so we can hold an exclusive flock without truncating pi's
         # edits. pi rewrites the file in place via its own open(...) calls; our
@@ -171,9 +181,10 @@ class ImprovePromptsManager:
                 "[ImprovePrompts] Failed to open introspection file %s for locking",
                 introspection_file,
             )
-            return _ROLLBACK_EXIT_CODE
+            return _RunPiResult(_ROLLBACK_EXIT_CODE, 0, 0)
 
         with lock_handle, _FileLock(lock_handle):
+            pending_before = self._count_pending_entries(introspection_file)
             main_backup = self._create_backup(introspection_file)
             archive_existed = archive_file.exists()
             archive_backup = self._create_backup(archive_file) if archive_existed else None
@@ -207,7 +218,10 @@ class ImprovePromptsManager:
                     )
                     if returncode == 0:
                         returncode = _ROLLBACK_EXIT_CODE
-                return returncode
+                    pending_after = pending_before
+                else:
+                    pending_after = self._count_pending_entries(introspection_file)
+                return _RunPiResult(returncode, pending_before, pending_after)
             finally:
                 if main_backup is not None and main_backup.exists():
                     main_backup.unlink()
@@ -340,7 +354,7 @@ class ImprovePromptsManager:
                 continue
             if pre == post:
                 continue
-            line_delta = post.count("\n") - pre.count("\n")
+            line_delta = len(post.splitlines()) - len(pre.splitlines())
             changes.append((name, line_delta))
         return changes
 

--- a/fix_die_repeat/runner_improve_prompts.py
+++ b/fix_die_repeat/runner_improve_prompts.py
@@ -7,6 +7,7 @@ pick up the improvements. Nothing inside the installed package is ever
 mutated.
 """
 
+import difflib
 import logging
 import shutil
 from collections.abc import Callable
@@ -24,6 +25,9 @@ from fix_die_repeat.config import (
 )
 from fix_die_repeat.prompts import clear_prompt_cache, render_prompt
 from fix_die_repeat.runner_introspection import _FileLock
+
+_SUMMARY_OPEN = "<IMPROVE_PROMPTS_SUMMARY>"
+_SUMMARY_CLOSE = "</IMPROVE_PROMPTS_SUMMARY>"
 
 # Templates exposed to pi for editing. Kept intentionally narrow: the
 # four top-level language-agnostic prompts that steer every run, plus the
@@ -54,6 +58,7 @@ class _RunPiResult:
     returncode: int
     pending_before: int
     pending_after: int
+    stdout: str
 
 
 class ImprovePromptsManager:
@@ -146,7 +151,7 @@ class ImprovePromptsManager:
 
         changes = self._compute_template_changes(template_paths, template_snapshot)
         entries_consumed = max(0, result.pending_before - result.pending_after)
-        self._emit_summary(changes, entries_consumed)
+        self._emit_summary(changes, entries_consumed, result.stdout)
 
         self.logger.info(
             "[ImprovePrompts] Done. User templates at %s now take precedence.",
@@ -181,7 +186,7 @@ class ImprovePromptsManager:
                 "[ImprovePrompts] Failed to open introspection file %s for locking",
                 introspection_file,
             )
-            return _RunPiResult(_ROLLBACK_EXIT_CODE, 0, 0)
+            return _RunPiResult(_ROLLBACK_EXIT_CODE, 0, 0, "")
 
         with lock_handle, _FileLock(lock_handle):
             pending_before = self._count_pending_entries(introspection_file)
@@ -190,7 +195,7 @@ class ImprovePromptsManager:
             archive_backup = self._create_backup(archive_file) if archive_existed else None
 
             try:
-                returncode, _stdout, _stderr = run_pi_callback(
+                returncode, stdout, _stderr = run_pi_callback(
                     "-p",
                     "--tools",
                     "read,write,edit",
@@ -221,7 +226,7 @@ class ImprovePromptsManager:
                     pending_after = pending_before
                 else:
                     pending_after = self._count_pending_entries(introspection_file)
-                return _RunPiResult(returncode, pending_before, pending_after)
+                return _RunPiResult(returncode, pending_before, pending_after, stdout)
             finally:
                 if main_backup is not None and main_backup.exists():
                     main_backup.unlink()
@@ -343,9 +348,14 @@ class ImprovePromptsManager:
     def _compute_template_changes(
         template_paths: dict[str, Path],
         snapshot: dict[str, str],
-    ) -> list[tuple[str, int]]:
-        """Return (name, line_delta) for every template pi modified."""
-        changes: list[tuple[str, int]] = []
+    ) -> list[tuple[str, int, int]]:
+        """Return (name, added, removed) for every template pi modified.
+
+        Uses unified-diff counts so an in-place rewrite that preserves line
+        count still surfaces as non-zero edits (e.g. ``+7 -7``), unlike a
+        bare net delta which would collapse to ``0``.
+        """
+        changes: list[tuple[str, int, int]] = []
         for name, path in template_paths.items():
             pre = snapshot.get(name, "")
             try:
@@ -354,16 +364,49 @@ class ImprovePromptsManager:
                 continue
             if pre == post:
                 continue
-            line_delta = len(post.splitlines()) - len(pre.splitlines())
-            changes.append((name, line_delta))
+            added = 0
+            removed = 0
+            for line in difflib.unified_diff(
+                pre.splitlines(),
+                post.splitlines(),
+                lineterm="",
+            ):
+                if line.startswith(("+++", "---")):
+                    continue
+                if line.startswith("+"):
+                    added += 1
+                elif line.startswith("-"):
+                    removed += 1
+            changes.append((name, added, removed))
         return changes
+
+    @staticmethod
+    def _extract_pi_summary(stdout: str) -> list[str] | None:
+        """Return the non-empty lines inside pi's summary markers, or ``None``.
+
+        ``None`` signals the marker contract was violated (open missing, close
+        missing, or close before open) so callers can warn once rather than
+        dump raw stdout.
+        """
+        if not stdout:
+            return None
+        open_idx = stdout.find(_SUMMARY_OPEN)
+        if open_idx == -1:
+            return None
+        inner_start = open_idx + len(_SUMMARY_OPEN)
+        close_idx = stdout.find(_SUMMARY_CLOSE, inner_start)
+        if close_idx == -1:
+            return None
+        block = stdout[inner_start:close_idx]
+        return [line.strip() for line in block.splitlines() if line.strip()]
 
     def _emit_summary(
         self,
-        changes: list[tuple[str, int]],
+        changes: list[tuple[str, int, int]],
         entries_consumed: int,
+        pi_stdout: str,
     ) -> None:
-        """Log a human-readable summary of template edits and entries consumed."""
+        """Log a human-readable summary of template edits, counts, and pi's rationale."""
         entries_word = "entry" if entries_consumed == 1 else "entries"
         if not changes:
             self.logger.info(
@@ -371,6 +414,7 @@ class ImprovePromptsManager:
                 entries_consumed,
                 entries_word,
             )
+            self._emit_pi_rationale(pi_stdout)
             return
         templates_word = "template" if len(changes) == 1 else "templates"
         self.logger.info(
@@ -380,18 +424,26 @@ class ImprovePromptsManager:
             entries_consumed,
             entries_word,
         )
-        for name, line_delta in changes:
-            if line_delta > 0:
-                delta_str = f"+{line_delta}"
-            elif line_delta < 0:
-                delta_str = str(line_delta)
-            else:
-                delta_str = "+0"
+        for name, added, removed in changes:
             self.logger.info(
-                "[ImprovePrompts]   %s (%s lines)",
+                "[ImprovePrompts]   %s (+%d -%d lines)",
                 name,
-                delta_str,
+                added,
+                removed,
             )
+        self._emit_pi_rationale(pi_stdout)
+
+    def _emit_pi_rationale(self, pi_stdout: str) -> None:
+        """Echo pi's markered summary block, or warn once if markers are absent."""
+        rationale = self._extract_pi_summary(pi_stdout)
+        if rationale is None:
+            self.logger.warning(
+                "[ImprovePrompts] pi did not wrap its summary in the expected markers; "
+                "skipping rationale echo. See pi.log for the raw output.",
+            )
+            return
+        for line in rationale:
+            self.logger.info("[ImprovePrompts]   pi: %s", line)
 
     def _ensure_user_templates(self, templates_dir: Path) -> dict[str, Path]:
         """Ensure the editable templates exist under ``templates_dir``.

--- a/fix_die_repeat/runner_improve_prompts.py
+++ b/fix_die_repeat/runner_improve_prompts.py
@@ -102,6 +102,8 @@ class ImprovePromptsManager:
         templates_dir = get_user_templates_dir()
         templates_dir.mkdir(parents=True, exist_ok=True)
         template_paths = self._ensure_user_templates(templates_dir)
+        template_snapshot = self._snapshot_templates(template_paths)
+        pending_before = self._count_pending_entries(introspection_file)
 
         archive_file = get_introspection_archive_file_path()
         prompt = render_prompt(
@@ -132,6 +134,11 @@ class ImprovePromptsManager:
                 returncode,
             )
             return returncode
+
+        pending_after = self._count_pending_entries(introspection_file)
+        changes = self._compute_template_changes(template_paths, template_snapshot)
+        entries_consumed = max(0, pending_before - pending_after)
+        self._emit_summary(changes, entries_consumed)
 
         self.logger.info(
             "[ImprovePrompts] Done. User templates at %s now take precedence.",
@@ -288,6 +295,89 @@ class ImprovePromptsManager:
             )
             return False
         return any(isinstance(doc, dict) and doc.get("status") == "pending" for doc in documents)
+
+    @staticmethod
+    def _snapshot_templates(template_paths: dict[str, Path]) -> dict[str, str]:
+        """Read each template's current content so we can diff post-pi."""
+        snapshot: dict[str, str] = {}
+        for name, path in template_paths.items():
+            try:
+                snapshot[name] = path.read_text() if path.exists() else ""
+            except OSError:
+                snapshot[name] = ""
+        return snapshot
+
+    def _count_pending_entries(self, introspection_file: Path) -> int:
+        """Count ``status: pending`` documents in the introspection YAML."""
+        if not introspection_file.exists():
+            return 0
+        try:
+            content = introspection_file.read_text()
+        except OSError:
+            return 0
+        if not content.strip():
+            return 0
+        try:
+            documents = list(yaml.safe_load_all(content))
+        except yaml.YAMLError:
+            return 0
+        return sum(
+            1 for doc in documents if isinstance(doc, dict) and doc.get("status") == "pending"
+        )
+
+    @staticmethod
+    def _compute_template_changes(
+        template_paths: dict[str, Path],
+        snapshot: dict[str, str],
+    ) -> list[tuple[str, int]]:
+        """Return (name, line_delta) for every template pi modified."""
+        changes: list[tuple[str, int]] = []
+        for name, path in template_paths.items():
+            pre = snapshot.get(name, "")
+            try:
+                post = path.read_text() if path.exists() else ""
+            except OSError:
+                continue
+            if pre == post:
+                continue
+            line_delta = post.count("\n") - pre.count("\n")
+            changes.append((name, line_delta))
+        return changes
+
+    def _emit_summary(
+        self,
+        changes: list[tuple[str, int]],
+        entries_consumed: int,
+    ) -> None:
+        """Log a human-readable summary of template edits and entries consumed."""
+        entries_word = "entry" if entries_consumed == 1 else "entries"
+        if not changes:
+            self.logger.info(
+                "[ImprovePrompts] Summary: no template edits made; %d introspection %s consumed.",
+                entries_consumed,
+                entries_word,
+            )
+            return
+        templates_word = "template" if len(changes) == 1 else "templates"
+        self.logger.info(
+            "[ImprovePrompts] Summary: %d %s modified, %d introspection %s consumed.",
+            len(changes),
+            templates_word,
+            entries_consumed,
+            entries_word,
+        )
+        for name, line_delta in changes:
+            if line_delta > 0:
+                delta_str = f"+{line_delta}"
+            elif line_delta < 0:
+                delta_str = str(line_delta)
+            else:
+                delta_str = "+0"
+            self.logger.info(
+                "[ImprovePrompts]   %s (%s lines)",
+                name,
+                delta_str,
+            )
 
     def _ensure_user_templates(self, templates_dir: Path) -> dict[str, Path]:
         """Ensure the editable templates exist under ``templates_dir``.

--- a/fix_die_repeat/runner_improve_prompts.py
+++ b/fix_die_repeat/runner_improve_prompts.py
@@ -439,7 +439,14 @@ class ImprovePromptsManager:
         self._emit_pi_rationale(pi_stdout)
 
     def _emit_pi_rationale(self, pi_stdout: str) -> None:
-        """Echo pi's marked summary block, or warn once if markers are absent."""
+        """Echo pi's marked summary block, or warn once if markers are absent.
+
+        Empty/whitespace-only stdout is treated as "no rationale provided" and
+        skipped silently — the marker-contract WARNING is reserved for cases
+        where pi emitted output but failed to wrap it in the expected markers.
+        """
+        if not pi_stdout or not pi_stdout.strip():
+            return
         rationale = self._extract_pi_summary(pi_stdout)
         if rationale is None:
             self.logger.warning(

--- a/fix_die_repeat/runner_improve_prompts.py
+++ b/fix_die_repeat/runner_improve_prompts.py
@@ -389,9 +389,9 @@ class ImprovePromptsManager:
     def _extract_pi_summary(stdout: str) -> list[str] | None:
         """Return the non-empty lines inside pi's summary markers, or ``None``.
 
-        ``None`` signals the marker contract was violated (open missing, close
-        missing, or close before open) so callers can warn once rather than
-        dump raw stdout.
+        ``None`` signals either that ``stdout`` was empty or that the marker
+        contract was violated (open missing, close missing, or close before
+        open) so callers can warn once rather than dump raw stdout.
         """
         if not stdout:
             return None

--- a/fix_die_repeat/runner_improve_prompts.py
+++ b/fix_die_repeat/runner_improve_prompts.py
@@ -354,6 +354,11 @@ class ImprovePromptsManager:
         Uses unified-diff counts so an in-place rewrite that preserves line
         count still surfaces as non-zero edits (e.g. ``+7 -7``), unlike a
         bare net delta which would collapse to ``0``.
+
+        ``splitlines(keepends=True)`` preserves line terminators so that
+        newline-only edits (CRLF/LF normalization or a flipped trailing
+        newline) report as non-zero +/- counts instead of a misleading
+        ``+0 -0`` after the ``pre != post`` guard has already passed.
         """
         changes: list[tuple[str, int, int]] = []
         for name, path in template_paths.items():
@@ -367,8 +372,8 @@ class ImprovePromptsManager:
             added = 0
             removed = 0
             for line in difflib.unified_diff(
-                pre.splitlines(),
-                post.splitlines(),
+                pre.splitlines(keepends=True),
+                post.splitlines(keepends=True),
                 lineterm="",
             ):
                 if line.startswith(("+++", "---")):
@@ -434,7 +439,7 @@ class ImprovePromptsManager:
         self._emit_pi_rationale(pi_stdout)
 
     def _emit_pi_rationale(self, pi_stdout: str) -> None:
-        """Echo pi's markered summary block, or warn once if markers are absent."""
+        """Echo pi's marked summary block, or warn once if markers are absent."""
         rationale = self._extract_pi_summary(pi_stdout)
         if rationale is None:
             self.logger.warning(

--- a/fix_die_repeat/runner_improve_prompts.py
+++ b/fix_die_repeat/runner_improve_prompts.py
@@ -376,7 +376,7 @@ class ImprovePromptsManager:
                 post.splitlines(keepends=True),
                 lineterm="",
             ):
-                if line.startswith(("+++", "---")):
+                if line.startswith(("+++ ", "--- ")):
                     continue
                 if line.startswith("+"):
                     added += 1

--- a/fix_die_repeat/templates/improve_prompts.j2
+++ b/fix_die_repeat/templates/improve_prompts.j2
@@ -38,10 +38,20 @@ These are the language-agnostic prompt templates (and their shared partials) who
    - Keep the 50 most recent `reviewed` entries in the main file, sorted by `date` descending.
    - Move `reviewed` entries older than 6 months to `{{ archive_file_path }}` (create the file if needed, prepend `---` between documents).
    - If the archive would be empty after the move, do not create it; if it already exists and would become empty, delete it.
-7. Print a short summary of:
-   - Which template files you edited and a one-line rationale per edit.
-   - How many introspection entries you marked as `reviewed`.
-   - Whether compaction ran and how many entries it moved.
+7. Print a short summary wrapped in these **exact** markers so the runner can
+   extract and surface it:
+
+   ```
+   <IMPROVE_PROMPTS_SUMMARY>
+   - <template path> — <one-line rationale>
+   - Entries reviewed: <N>
+   - Compaction: <skipped | moved N entries>
+   </IMPROVE_PROMPTS_SUMMARY>
+   ```
+
+   One `- <template path> — <rationale>` line per edited template. Put nothing
+   else between the open and close markers. Content outside the markers will be
+   ignored.
 
 # Guidelines
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 """Shared pytest fixtures for fix-die-repeat tests."""
 
+import os
 from collections.abc import Iterator
 from pathlib import Path
 from unittest.mock import patch
@@ -25,6 +26,12 @@ def _isolated_fdr_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     fdr_home = tmp_path / "fdr_home"
     monkeypatch.setenv("FDR_HOME", str(fdr_home))
     monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+    # Pre-commit injects GIT_DIR / GIT_WORK_TREE / GIT_INDEX_FILE into the hook env.
+    # Tests that `git init` a tmp dir or construct `Paths()` must not inherit that
+    # context or git operates on the parent repo instead of the test's sandbox.
+    for key in list(os.environ):
+        if key.startswith("GIT_"):
+            monkeypatch.delenv(key, raising=False)
     return fdr_home
 
 

--- a/tests/test_runner_improve_prompts_summary.py
+++ b/tests/test_runner_improve_prompts_summary.py
@@ -98,10 +98,18 @@ class TestSummary:
             rc = manager.run_improve_prompts(spy)
 
         assert rc == 0
-        messages = " ".join(r.message for r in caplog.records).lower()
-        assert "summary" in messages
-        assert "no" in messages
-        assert any(keyword in messages for keyword in ("edit", "change", "modif"))
+        summary_messages = [r.message for r in caplog.records if "Summary" in r.message]
+        assert summary_messages, "expected at least one [ImprovePrompts] Summary log record"
+        joined = " ".join(summary_messages).lower()
+        assert any(
+            phrase in joined
+            for phrase in (
+                "no template edits",
+                "no edits made",
+                "no changes made",
+                "no templates modified",
+            )
+        )
 
     def test_summary_reports_introspection_entries_consumed(
         self,
@@ -166,3 +174,107 @@ class TestSummary:
         post_summary = " ".join(r.message for r in caplog.records[summary_index:])
         assert "fix_checks.j2" in post_summary
         assert "+3" in post_summary or "3 line" in post_summary
+
+    def test_summary_reports_inline_rewrite_with_same_line_count(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """An in-place rewrite preserving line count must report non-zero +/- counts.
+
+        Regression: the old net-delta metric reported ``(+0 lines)`` when pi
+        reworded every line but kept the line count stable — indistinguishable
+        from "no edit" in the log output.
+        """
+        _write_introspection(_PENDING_ENTRY)
+        templates_dir = get_user_templates_dir()
+
+        def rewriting_pi(*_args: str) -> tuple[int, str, str]:
+            target = templates_dir / "partials/_critical_checklist.j2"
+            original = target.read_text().splitlines()
+            rewritten = [f"ZZZ rewritten line {i}" for i in range(len(original))]
+            target.write_text("\n".join(rewritten) + "\n")
+            return (0, "", "")
+
+        manager = _manager()
+        with caplog.at_level(logging.INFO, logger="test-improve-prompts-summary"):
+            rc = manager.run_improve_prompts(rewriting_pi)
+
+        assert rc == 0
+        summary_index = next(
+            (i for i, r in enumerate(caplog.records) if "Summary" in r.message),
+            None,
+        )
+        assert summary_index is not None, "expected a [ImprovePrompts] Summary log record"
+        post_summary = " ".join(r.message for r in caplog.records[summary_index:])
+        assert "_critical_checklist.j2" in post_summary
+        assert "(+0 lines)" not in post_summary, (
+            "a rewrite touching every line must not report the misleading old '+0 lines' format"
+        )
+        # The new format encodes both sides explicitly, e.g. "(+7 -7 lines)".
+        # Require that the counts surfaced are non-zero on at least one side.
+        assert "+0 -0" not in post_summary
+        assert any(f"+{n}" in post_summary for n in range(1, 200))
+        assert any(f"-{n}" in post_summary for n in range(1, 200))
+
+    def test_summary_includes_pi_rationale(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Pi's markered summary block must be extracted and echoed in the log."""
+        _write_introspection(_PENDING_ENTRY)
+        templates_dir = get_user_templates_dir()
+
+        def rationale_pi(*_args: str) -> tuple[int, str, str]:
+            (templates_dir / "fix_checks.j2").write_text("edited by pi\n")
+            stdout = (
+                "preamble noise that must not be echoed\n"
+                "some tool-use chatter\n"
+                "<IMPROVE_PROMPTS_SUMMARY>\n"
+                "- fix_checks.j2 - added retry guidance\n"
+                "- Entries reviewed: 1\n"
+                "- Compaction: skipped\n"
+                "</IMPROVE_PROMPTS_SUMMARY>\n"
+                "trailing noise that must not be echoed\n"
+            )
+            return (0, stdout, "")
+
+        manager = _manager()
+        with caplog.at_level(logging.INFO, logger="test-improve-prompts-summary"):
+            rc = manager.run_improve_prompts(rationale_pi)
+
+        assert rc == 0
+        pi_prefixed = [r.message for r in caplog.records if "pi:" in r.message]
+        joined = "\n".join(pi_prefixed)
+        assert "added retry guidance" in joined
+        assert "Entries reviewed: 1" in joined
+        assert "Compaction: skipped" in joined
+        all_messages = " ".join(r.message for r in caplog.records)
+        assert "preamble noise" not in all_messages
+        assert "trailing noise" not in all_messages
+        assert "tool-use chatter" not in all_messages
+
+    def test_summary_tolerates_missing_markers(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """If pi ignores the marker contract, the runner warns once and moves on."""
+        _write_introspection(_PENDING_ENTRY)
+        templates_dir = get_user_templates_dir()
+
+        def noncompliant_pi(*_args: str) -> tuple[int, str, str]:
+            (templates_dir / "fix_checks.j2").write_text("edited by pi\n")
+            return (0, "pi produced output but forgot the markers entirely", "")
+
+        manager = _manager()
+        with caplog.at_level(logging.INFO, logger="test-improve-prompts-summary"):
+            rc = manager.run_improve_prompts(noncompliant_pi)
+
+        assert rc == 0
+        warnings = [
+            r.message
+            for r in caplog.records
+            if r.levelno >= logging.WARNING and "summary" in r.message.lower()
+        ]
+        assert len(warnings) == 1, "expected exactly one warning about the missing summary markers"
+        pi_prefixed = [r.message for r in caplog.records if "pi:" in r.message]
+        assert not pi_prefixed, "no rationale should be echoed when markers are missing"

--- a/tests/test_runner_improve_prompts_summary.py
+++ b/tests/test_runner_improve_prompts_summary.py
@@ -216,11 +216,51 @@ class TestSummary:
         assert any(f"+{n}" in post_summary for n in range(1, 200))
         assert any(f"-{n}" in post_summary for n in range(1, 200))
 
+    def test_summary_reports_trailing_newline_edit_with_non_zero_counts(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        r"""A trailing-newline-only edit must surface as non-zero +/- counts.
+
+        Regression: ``splitlines()`` without ``keepends=True`` drops trailing
+        terminators, so if pi only strips or adds a final ``\n`` the diff loop
+        sees identical line lists and reports ``+0 -0`` — even though the
+        ``pre != post`` guard already fired. The summary then contradicts
+        itself: "this file changed ... (+0 -0 lines)".
+        """
+        _write_introspection(_PENDING_ENTRY)
+        templates_dir = get_user_templates_dir()
+
+        def strip_trailing_newline_pi(*_args: str) -> tuple[int, str, str]:
+            target = templates_dir / "fix_checks.j2"
+            base = target.read_text()
+            if base.endswith("\n"):
+                target.write_text(base.rstrip("\n"))
+            else:
+                target.write_text(base + "\n")
+            return (0, "", "")
+
+        manager = _manager()
+        with caplog.at_level(logging.INFO, logger="test-improve-prompts-summary"):
+            rc = manager.run_improve_prompts(strip_trailing_newline_pi)
+
+        assert rc == 0
+        summary_index = next(
+            (i for i, r in enumerate(caplog.records) if "Summary" in r.message),
+            None,
+        )
+        assert summary_index is not None, "expected a [ImprovePrompts] Summary log record"
+        post_summary = " ".join(r.message for r in caplog.records[summary_index:])
+        assert "fix_checks.j2" in post_summary
+        assert "+0 -0" not in post_summary, (
+            "a trailing-newline edit must not report '+0 -0' once pre != post has already fired"
+        )
+
     def test_summary_includes_pi_rationale(
         self,
         caplog: pytest.LogCaptureFixture,
     ) -> None:
-        """Pi's markered summary block must be extracted and echoed in the log."""
+        """Pi's marked summary block must be extracted and echoed in the log."""
         _write_introspection(_PENDING_ENTRY)
         templates_dir = get_user_templates_dir()
 

--- a/tests/test_runner_improve_prompts_summary.py
+++ b/tests/test_runner_improve_prompts_summary.py
@@ -1,0 +1,168 @@
+"""Tests for the post-run summary emitted by ``--improve-prompts``.
+
+Kept in a sibling file from ``test_runner_improve_prompts.py`` purely to keep
+the summary-specific cases grouped; pytest collects both files the same way.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from fix_die_repeat.config import (
+    Settings,
+    get_introspection_file_path,
+    get_user_templates_dir,
+)
+from fix_die_repeat.runner_improve_prompts import ImprovePromptsManager
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import pytest
+
+
+class _PiSpy:
+    """Captures pi invocations so tests can assert on arguments."""
+
+    def __init__(self, returncode: int = 0) -> None:
+        self.returncode = returncode
+        self.calls: list[tuple[str, ...]] = []
+
+    def __call__(self, *args: str) -> tuple[int, str, str]:
+        self.calls.append(args)
+        return (self.returncode, "", "")
+
+
+def _manager() -> ImprovePromptsManager:
+    """Build a manager with a stub logger."""
+    return ImprovePromptsManager(
+        settings=Settings(),
+        logger=logging.getLogger("test-improve-prompts-summary"),
+    )
+
+
+def _write_introspection(content: str) -> Path:
+    """Seed <FDR_HOME>/introspection.yaml with the given raw content."""
+    path = get_introspection_file_path()
+    path.write_text(content)
+    return path
+
+
+_PENDING_ENTRY = (
+    "date: '2026-04-01'\nstatus: pending\npr_number: 1\n"
+    "pr_url: https://example.com/pr/1\nproject: demo\nthreads: []\n"
+)
+
+
+class TestSummary:
+    """A successful run should print a summary of what pi changed."""
+
+    def test_summary_lists_each_modified_template(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """When pi edits templates, the summary names every changed file."""
+        _write_introspection(_PENDING_ENTRY)
+        templates_dir = get_user_templates_dir()
+
+        def editing_pi(*_args: str) -> tuple[int, str, str]:
+            (templates_dir / "local_review.j2").write_text("edited by pi\n")
+            (templates_dir / "partials/_critical_checklist.j2").write_text("edited partial\n")
+            return (0, "", "")
+
+        manager = _manager()
+        with caplog.at_level(logging.INFO, logger="test-improve-prompts-summary"):
+            rc = manager.run_improve_prompts(editing_pi)
+
+        assert rc == 0
+        summary_index = next(
+            (i for i, r in enumerate(caplog.records) if "Summary" in r.message),
+            None,
+        )
+        assert summary_index is not None, "expected a [ImprovePrompts] Summary log record"
+        post_summary = " ".join(r.message for r in caplog.records[summary_index:])
+        assert "local_review.j2" in post_summary
+        assert "_critical_checklist.j2" in post_summary
+
+    def test_summary_reports_noop_explicitly(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A run where pi edits zero templates must say so, not go silent."""
+        _write_introspection(_PENDING_ENTRY)
+        spy = _PiSpy()
+        manager = _manager()
+
+        with caplog.at_level(logging.INFO, logger="test-improve-prompts-summary"):
+            rc = manager.run_improve_prompts(spy)
+
+        assert rc == 0
+        messages = " ".join(r.message for r in caplog.records).lower()
+        assert "summary" in messages
+        assert "no" in messages
+        assert any(keyword in messages for keyword in ("edit", "change", "modif"))
+
+    def test_summary_reports_introspection_entries_consumed(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """The summary reports how many pending entries transitioned away."""
+        path = _write_introspection(
+            "date: '2026-04-01'\nstatus: pending\npr_number: 1\n"
+            "pr_url: https://example.com/pr/1\nproject: demo\nthreads: []\n"
+            "---\n"
+            "date: '2026-04-02'\nstatus: pending\npr_number: 2\n"
+            "pr_url: https://example.com/pr/2\nproject: demo\nthreads: []\n",
+        )
+
+        def consuming_pi(*_args: str) -> tuple[int, str, str]:
+            path.write_text(
+                "date: '2026-04-01'\nstatus: reviewed\npr_number: 1\n"
+                "pr_url: https://example.com/pr/1\nproject: demo\nthreads: []\n"
+                "---\n"
+                "date: '2026-04-02'\nstatus: reviewed\npr_number: 2\n"
+                "pr_url: https://example.com/pr/2\nproject: demo\nthreads: []\n",
+            )
+            return (0, "", "")
+
+        manager = _manager()
+        with caplog.at_level(logging.INFO, logger="test-improve-prompts-summary"):
+            rc = manager.run_improve_prompts(consuming_pi)
+
+        assert rc == 0
+        summary_messages = [r.message for r in caplog.records if "Summary" in r.message]
+        assert summary_messages, "expected at least one [ImprovePrompts] Summary log record"
+        joined = " ".join(summary_messages).lower()
+        # Count "2" must appear with "entries" context, not just anywhere in dates/paths.
+        assert "2 introspection" in joined or "2 entries" in joined or "2 pending" in joined
+
+    def test_summary_shows_line_delta_per_template(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """The per-template line should include a diff-derived hint (line delta)."""
+        _write_introspection(_PENDING_ENTRY)
+        templates_dir = get_user_templates_dir()
+
+        def extending_pi(*_args: str) -> tuple[int, str, str]:
+            target = templates_dir / "fix_checks.j2"
+            base = target.read_text()
+            if not base.endswith("\n"):
+                base += "\n"
+            target.write_text(base + "line a\nline b\nline c\n")
+            return (0, "", "")
+
+        manager = _manager()
+        with caplog.at_level(logging.INFO, logger="test-improve-prompts-summary"):
+            rc = manager.run_improve_prompts(extending_pi)
+
+        assert rc == 0
+        summary_index = next(
+            (i for i, r in enumerate(caplog.records) if "Summary" in r.message),
+            None,
+        )
+        assert summary_index is not None, "expected a [ImprovePrompts] Summary log record"
+        post_summary = " ".join(r.message for r in caplog.records[summary_index:])
+        assert "fix_checks.j2" in post_summary
+        assert "+3" in post_summary or "3 line" in post_summary

--- a/tests/test_runner_improve_prompts_summary.py
+++ b/tests/test_runner_improve_prompts_summary.py
@@ -1,6 +1,6 @@
 """Tests for the post-run summary emitted by ``--improve-prompts``.
 
-Kept in a sibling file from ``test_runner_improve_prompts.py`` purely to keep
+Kept in a sibling file of ``test_runner_improve_prompts.py`` purely to keep
 the summary-specific cases grouped; pytest collects both files the same way.
 """
 

--- a/tests/test_runner_improve_prompts_summary.py
+++ b/tests/test_runner_improve_prompts_summary.py
@@ -318,3 +318,36 @@ class TestSummary:
         assert len(warnings) == 1, "expected exactly one warning about the missing summary markers"
         pi_prefixed = [r.message for r in caplog.records if "pi:" in r.message]
         assert not pi_prefixed, "no rationale should be echoed when markers are missing"
+
+    def test_summary_silent_when_pi_stdout_is_empty(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Empty/whitespace-only pi stdout is benign and must not trigger a marker warning.
+
+        Regression: previously ``_emit_pi_rationale`` logged a WARNING pointing
+        users to ``pi.log`` whenever stdout was empty, conflating "no rationale
+        produced" with "marker contract violated."
+        """
+        _write_introspection(_PENDING_ENTRY)
+        templates_dir = get_user_templates_dir()
+
+        def silent_pi(*_args: str) -> tuple[int, str, str]:
+            (templates_dir / "fix_checks.j2").write_text("edited by pi\n")
+            return (0, "   \n\t\n", "")
+
+        manager = _manager()
+        with caplog.at_level(logging.INFO, logger="test-improve-prompts-summary"):
+            rc = manager.run_improve_prompts(silent_pi)
+
+        assert rc == 0
+        marker_warnings = [
+            r.message
+            for r in caplog.records
+            if r.levelno >= logging.WARNING and "markers" in r.message.lower()
+        ]
+        assert not marker_warnings, (
+            "empty/whitespace-only pi stdout should not emit a marker-contract warning"
+        )
+        pi_prefixed = [r.message for r in caplog.records if "pi:" in r.message]
+        assert not pi_prefixed, "no rationale lines should be echoed when stdout is empty"

--- a/tests/test_runner_improve_prompts_summary.py
+++ b/tests/test_runner_improve_prompts_summary.py
@@ -319,6 +319,43 @@ class TestSummary:
         pi_prefixed = [r.message for r in caplog.records if "pi:" in r.message]
         assert not pi_prefixed, "no rationale should be echoed when markers are missing"
 
+    def test_summary_counts_added_lines_whose_content_starts_with_plus_plus_plus(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Added lines whose raw content begins with ``+++`` must be counted.
+
+        Regression: the old header-skip check ``startswith(("+++", "---"))``
+        also matched real added lines whose content starts with ``+++`` (since
+        the diff line becomes ``++++...``), causing an undercount and a
+        misleading ``+0 -0`` when every changed line happened to share that
+        prefix.
+        """
+        _write_introspection(_PENDING_ENTRY)
+        templates_dir = get_user_templates_dir()
+
+        def plus_prefix_pi(*_args: str) -> tuple[int, str, str]:
+            target = templates_dir / "fix_checks.j2"
+            target.write_text("+++marker line one\n+++marker line two\n")
+            return (0, "", "")
+
+        manager = _manager()
+        with caplog.at_level(logging.INFO, logger="test-improve-prompts-summary"):
+            rc = manager.run_improve_prompts(plus_prefix_pi)
+
+        assert rc == 0
+        summary_index = next(
+            (i for i, r in enumerate(caplog.records) if "Summary" in r.message),
+            None,
+        )
+        assert summary_index is not None, "expected a [ImprovePrompts] Summary log record"
+        post_summary = " ".join(r.message for r in caplog.records[summary_index:])
+        assert "fix_checks.j2" in post_summary
+        assert "+2" in post_summary, (
+            "two added lines starting with '+++' must both be counted as additions, "
+            "not mistaken for diff headers"
+        )
+
     def test_summary_silent_when_pi_stdout_is_empty(
         self,
         caplog: pytest.LogCaptureFixture,


### PR DESCRIPTION
## Summary

- After a successful `--improve-prompts` run, log a summary banner listing each modified user template with a line-count delta and the number of introspection entries consumed; no-op runs (pi made zero edits) say so explicitly. Closes #23.
- Drive-by fix to `tests/conftest.py`: scrub inherited `GIT_*` env vars in the autouse fixture so the pre-commit hook's test run doesn't inherit `GIT_DIR`/`GIT_WORK_TREE` and make `git init`/`Paths()` operate on the parent repo instead of the tmp sandbox. Pre-existing, surfaced while getting this PR through pre-commit; kept as its own commit.

## Test plan

- [x] `./scripts/ci.sh --check-only` → 510 passed, coverage 85.71%, ruff + mypy + format clean.
- [x] 4 new TDD tests in `tests/test_runner_improve_prompts_summary.py` covering each AC (modified templates listed, no-op explicit message, entries-consumed count, per-template line delta).
- [x] `GIT_DIR=... GIT_WORK_TREE=... uv run pytest tests/test_config.py::TestPaths` (simulated pre-commit env) → 12/12 pass.
- [x] Pre-commit hooks pass on both commits.